### PR TITLE
Fix Duplicate scheduleUpdate request

### DIFF
--- a/MMM-CoinMarketCap.js
+++ b/MMM-CoinMarketCap.js
@@ -281,6 +281,7 @@ Module.register("MMM-CoinMarketCap", {
 	 */
 	scheduleUpdate: function() {
 		var self = this;
+		if (self.updateTimer) clearInterval(self.updateTimer);
 		self.updateTimer = setInterval(function() { self.getAllCurrencyDetails(1); }, self.config.updateInterval);
 		self.log( self.translate("UPDATE_SCHEDULED", { "minutes": (self.config.updateInterval / (1000 * 60)) }) );
 	},


### PR DESCRIPTION
<img width="1134" alt="Screen Shot 2021-10-17 at 08 03 36" src="https://user-images.githubusercontent.com/4002252/137606273-dc137562-230c-4d96-9a18-5536372f44a7.png">
Module requested twice times every 10 mins to api. This made my key reatched limit.

Reason is scheduleUpdate function was called twice so it created 2 Intervals.